### PR TITLE
Potential fix for code scanning alert no. 17: Clear-text logging of sensitive information

### DIFF
--- a/bluesky_common.py
+++ b/bluesky_common.py
@@ -57,7 +57,7 @@ def get_bluesky_credentials(include_source=False):
 
 
 def login_client():
-    username, password, password_source = get_bluesky_credentials(include_source=True)
+    username, password = get_bluesky_credentials()
     raw_attempts = os.getenv(
         "BLUESKY_LOGIN_RETRY_ATTEMPTS", str(DEFAULT_LOGIN_RETRY_ATTEMPTS)
     )

--- a/bluesky_common.py
+++ b/bluesky_common.py
@@ -73,7 +73,7 @@ def login_client():
     )
 
     client = Client()
-    print(f"Using {password_source} for Bluesky authentication.")
+    print("Using configured credentials for Bluesky authentication.")
     for attempt in range(1, max_attempts + 1):
         try:
             client.login(username, password)

--- a/tests/test_bot_logic.py
+++ b/tests/test_bot_logic.py
@@ -153,7 +153,9 @@ class LoginClientRetryTests(unittest.TestCase):
         )
         self.assertTrue(
             any(
-                call.args and "BLUESKY_APP_PASSWORD" in call.args[0]
+                call.args
+                and "Using configured credentials for Bluesky authentication."
+                in call.args[0]
                 for call in mock_print.call_args_list
             )
         )


### PR DESCRIPTION
Potential fix for [https://github.com/chris-gillatt/thejokebot/security/code-scanning/17](https://github.com/chris-gillatt/thejokebot/security/code-scanning/17)

To fix clear-text sensitive logging, avoid interpolating any value that originates from password retrieval into log/print output.  
The best minimal fix is in `bluesky_common.py` inside `login_client()`: replace the current message

```py
print(f"Using {password_source} for Bluesky authentication.")
```

with a static message that contains no credential-derived data, e.g.:

```py
print("Using configured credentials for Bluesky authentication.")
```

This preserves runtime behavior (authentication/retry logic unchanged), still provides operational visibility, and removes the tainted flow into the logging sink. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
